### PR TITLE
Update order of deploy-software script

### DIFF
--- a/tools/deployment/developer/common/150-deploy-software.sh
+++ b/tools/deployment/developer/common/150-deploy-software.sh
@@ -40,9 +40,9 @@ ${PEGLEG} site -p deployment_files/ collect ${PL_SITE} -s ${PL_OUTPUT}
 cp -rp ${CURRENT_DIR}/${PL_OUTPUT} ${SY_PATH}/${SY_OUTPUT}
 
 # Deploy the site
+. tools/deployment/common/os-env.sh
 cd ${SY_PATH}
 : ${SHIPYARD:="./tools/shipyard.sh"}
-. tools/deployment/common/os-env.sh
 : ${SY_AUTH:="--os-project-domain-name=$OS_PROJECT_DOMAIN_NAME \
               --os-user-domain-name=$OS_USER_DOMAIN_NAME \
               --os-project-name=$OS_PROJECT_NAME \


### PR DESCRIPTION
Currently, the environment variables in `/etc/openstack/clouds.yaml`
are exported from the `airship-shipyard` directory rather than the
airskiff directory, resulting in a missing file error. This commit
updates the deploy-software script to export the environment
variables prior to changing directories.