### PR TITLE
Add type directory to suppress Pegleg errors

### DIFF
--- a/deployment_files/type/single-node/v1.0demo/.gitignore
+++ b/deployment_files/type/single-node/v1.0demo/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Pegleg expects a directory type/single-node/v1.0demo/.gitignore and
fails without it. This commit adds the directory as a placeholder.