### PR TITLE
tools: Add proxy setup script for Pegleg versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,14 @@ build behind your proxy servers:
     export USE_PROXY=true
     export PROXY=${http_proxy}
 
+Run the ``setup-proxy.sh`` script to add your proxy server to the Pegleg
+software versions document, enabling Armada to clone charts behind your proxy
+server.
+
+.. code-block:: bash
+
+    ./tools/deployment/common/setup-proxy.sh
+
 After the ``OpenStack-Helm`` and ``OpenStack-Helm-Infra`` repositories are
 cloned to your parent directory by the
 ``tools/deployment/developer/common/005-make-airship.sh`` script during the

--- a/tools/deployment/common/setup-proxy.sh
+++ b/tools/deployment/common/setup-proxy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -xe
+
+sed -i -e "/type:/ a\        proxy_server: ${PROXY}" \
+  deployment_files/global/v1.0demo/software/config/versions.yaml


### PR DESCRIPTION
This commit adds a script to add the proxy server key/value pairs to
the Pegleg software versions document. This enables Armada to clone
charts behind a proxy server.