### PR TITLE
tools: Update Ceph charts locations

### DIFF
--- a/tools/deployment/developer/ceph/040-ceph.sh
+++ b/tools/deployment/developer/ceph/040-ceph.sh
@@ -17,8 +17,8 @@
 set -xe
 
 CURRENT_DIR="$(pwd)"
-: ${OSH_PATH:="../openstack-helm"}
-cd ${OSH_PATH}
+: ${OSH_INFRA_PATH:="../openstack-helm-infra"}
+cd ${OSH_INFRA_PATH}
 
 #NOTE: Lint and package chart
 for CHART in ceph-mon ceph-osd ceph-client ceph-provisioners; do

--- a/tools/deployment/developer/ceph/045-ceph-ns-activate.sh
+++ b/tools/deployment/developer/ceph/045-ceph-ns-activate.sh
@@ -17,8 +17,8 @@
 set -xe
 
 CURRENT_DIR="$(pwd)"
-: ${OSH_PATH:="../openstack-helm"}
-cd ${OSH_PATH}
+: ${OSH_INFRA_PATH:="../openstack-helm-infra"}
+cd ${OSH_INFRA_PATH}
 
 #NOTE: Lint and package chart
 make ceph-client


### PR DESCRIPTION
This commit changes the location of the Ceph charts from the
OpenStack-Helm repository to the OpenStack-Helm-Infra repository to
reflect changes made to OpenStack-Helm.