### PR TITLE
 tools: Update MariaDB chart location

### DIFF
--- a/tools/deployment/developer/common/050-mariadb.sh
+++ b/tools/deployment/developer/common/050-mariadb.sh
@@ -17,8 +17,8 @@
 set -xe
 
 CURRENT_DIR="$(pwd)"
-: ${OSH_PATH:="../openstack-helm"}
-cd ${OSH_PATH}
+: ${OSH_INFRA_PATH:="../openstack-helm-infra"}
+cd ${OSH_INFRA_PATH}
 
 #NOTE: Lint and package chart
 make mariadb


### PR DESCRIPTION
This commit changes the location of the MariaDB chart from the
OpenStack-Helm repository to the OpenStack-Helm-Infra repository to
reflect changes made to OpenStack-Helm.