### PR TITLE
tools: Update PostgreSQL chart location

### DIFF
--- a/tools/deployment/developer/common/090-postgresql.sh
+++ b/tools/deployment/developer/common/090-postgresql.sh
@@ -17,8 +17,8 @@
 set -xe
 
 CURRENT_DIR="$(pwd)"
-: ${OSH_PATH:="../openstack-helm"}
-cd ${OSH_PATH}
+: ${OSH_INFRA_PATH:="../openstack-helm-infra"}
+cd ${OSH_INFRA_PATH}
 
 #NOTE: Lint and package chart
 make postgresql


### PR DESCRIPTION
This commit updates the location of the PostgreSQL chart from the
OpenStack-Helm repository to the OpenStack-Helm-Infra repository to
reflect changes made to the OpenStack-Helm project.