### PR TITLE
feat(tools): enable executing deploy-software more than once

### DIFF
--- a/tools/deployment/developer/common/150-deploy-software.sh
+++ b/tools/deployment/developer/common/150-deploy-software.sh
@@ -54,7 +54,7 @@ ${SHIPYARD} ${SY_AUTH} create configdocs the-design \
              --directory=/target/${PL_OUTPUT}
 
 ${SHIPYARD} ${SY_AUTH} commit configdocs --force
-${SHIPYARD} ${SY_AUTH} create action update_software
+${SHIPYARD} ${SY_AUTH} create action update_software --allow-intermediate-commits
 
 # To see the status of the action:
 #     shipyard describe action 01CKPKZ2FXSMYV0V99GH3R3W3P


### PR DESCRIPTION
> Before this change attempting to execute deploy-software a second
> time caused an error because an intermediate commit was create.
> 
> Now, deploy-software is able to be executed more than once because
> intermediate commits are allowed.

I don't know if this is a good idea, so happy to implement a better method if possible. It's convenient being able to reuse this script.