### PR TITLE
Fix variable names

### DIFF
--- a/tools/deployment/developer/common/090-postgresql.sh
+++ b/tools/deployment/developer/common/090-postgresql.sh
@@ -29,7 +29,7 @@ helm upgrade --install postgresql ./postgresql \
     --namespace=ucp \
     --set pod.replicas.server=1 \
     ${AS_EXTRA_HELM_ARGS} \
-    ${AS_EXTRA_HELM_ARGS_MARIADB}
+    ${AS_EXTRA_HELM_ARGS_POSTGRESQL}
 
 #NOTE: Wait for deploy
 ./tools/deployment/common/wait-for-pods.sh ucp

--- a/tools/deployment/developer/common/100-barbican.sh
+++ b/tools/deployment/developer/common/100-barbican.sh
@@ -28,7 +28,7 @@ make barbican
 helm upgrade --install barbican ./barbican \
     --namespace=ucp \
     ${AS_EXTRA_HELM_ARGS} \
-    ${AS_EXTRA_HELM_ARGS_KEYSTONE}
+    ${AS_EXTRA_HELM_ARGS_BARBICAN}
 
 #NOTE: Wait for deploy
 ./tools/deployment/common/wait-for-pods.sh ucp

--- a/tools/deployment/developer/common/110-deckhand.sh
+++ b/tools/deployment/developer/common/110-deckhand.sh
@@ -31,7 +31,7 @@ make charts
 helm upgrade --install deckhand ./charts/deckhand \
     --namespace=ucp \
     ${AS_EXTRA_HELM_ARGS} \
-    ${AS_EXTRA_HELM_ARGS_MARIADB}
+    ${AS_EXTRA_HELM_ARGS_DECKHAND}
 
 #NOTE: Wait for deploy
 ${CURRENT_DIR}/tools/deployment/common/wait-for-pods.sh ucp

--- a/tools/deployment/developer/common/120-armada.sh
+++ b/tools/deployment/developer/common/120-armada.sh
@@ -39,7 +39,7 @@ helm upgrade --install armada ./charts/armada \
     --namespace=ucp \
     --values /tmp/armada.yaml \
     ${AS_EXTRA_HELM_ARGS} \
-    ${AS_EXTRA_HELM_ARGS_MARIADB}
+    ${AS_EXTRA_HELM_ARGS_ARMADA}
 
 #NOTE: Wait for deploy
 ${CURRENT_DIR}/tools/deployment/common/wait-for-pods.sh ucp

--- a/tools/deployment/developer/common/130-shipyard.sh
+++ b/tools/deployment/developer/common/130-shipyard.sh
@@ -58,7 +58,7 @@ helm upgrade --install shipyard ./charts/shipyard \
     --namespace=ucp \
     --values=/tmp/shipyard.yaml \
     ${AS_EXTRA_HELM_ARGS} \
-    ${AS_EXTRA_HELM_ARGS_MARIADB}
+    ${AS_EXTRA_HELM_ARGS_SHIPYARD}
 
 #NOTE: Wait for deploy
 ${CURRENT_DIR}/tools/deployment/common/wait-for-pods.sh ucp


### PR DESCRIPTION
This patchset fixes a number of misnamed variables in the deployment
shell scripts.

Signed-off-by: Tin Lam <tin@irrational.io>