### PR TITLE
fix(tools): update Pegleg usage to reflect changes

### DIFF
--- a/tools/deployment/developer/common/150-deploy-software.sh
+++ b/tools/deployment/developer/common/150-deploy-software.sh
@@ -31,11 +31,11 @@ CURRENT_DIR="$(pwd)"
 cd ${CURRENT_DIR}
 
 # Lint deployment manifests
-IMAGE=${PL_IMAGE} ${PEGLEG} site -r deployment_files/ lint ${PL_SITE}
+IMAGE=${PL_IMAGE} ${PEGLEG} site -r ./deployment_files/ lint ${PL_SITE}
 
 # Collect the deployment manifests that will be used
 mkdir -p ${PL_OUTPUT}
-IMAGE=${PL_IMAGE} ${PEGLEG} site -r deployment_files/ collect ${PL_SITE} -s ${PL_OUTPUT}
+IMAGE=${PL_IMAGE} ${PEGLEG} site -r ./deployment_files/ collect ${PL_SITE} -s ${PL_OUTPUT}
 cp -rp ${CURRENT_DIR}/${PL_OUTPUT} ${SY_PATH}/${SY_OUTPUT}
 
 # Deploy the site


### PR DESCRIPTION
> Pegleg's -r flag has undergone changes and now requires passing
> a directory reference instead of just a string.

Not sure on the best terms to use here. Happy to update commit message.